### PR TITLE
safeStringify checks for undefined

### DIFF
--- a/lib/compile/codegen/code.ts
+++ b/lib/compile/codegen/code.ts
@@ -146,7 +146,7 @@ export function stringify(x: unknown): Code {
 }
 
 export function safeStringify(x: unknown): string {
-  return JSON.stringify(x)
+  return x==undefined?undefined:JSON.stringify(x)
     .replace(/\u2028/g, "\\u2028")
     .replace(/\u2029/g, "\\u2029")
 }


### PR DESCRIPTION

**What issue does this pull request resolve?**

fix for stringifying undefined vars when validating

passing in undefined causes the error:
Cannot read properties of undefined (reading 'replace')
        at safeStringify (,,,\node_modules\ajv\dist\compile\codegen\code.js:136:9)


**What changes did you make?**

added deliberate undefined check

**Is there anything that requires more attention while reviewing?**
No